### PR TITLE
#308 Bli kvitt emotak-utils avhengigheten i emottak-state-service

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,7 +69,6 @@ dependencies {
     implementation(libs.flyway.postgresql)
     implementation(libs.postgresql)
     implementation(libs.token.validation.ktor.v3)
-    implementation(libs.emottak.utils)
     testImplementation(testLibs.bundles.kotest)
     testImplementation(testLibs.kotest.assertions.arrow)
     testImplementation(testLibs.kotest.extensions.jvm)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,7 +27,6 @@ dependencyResolutionManagement {
             version("prometheus", "1.12.4")
             version("logback", "1.4.11")
             version("logstash", "7.4")
-            version("emottak-utils", "0.3.3")
 
             library("arrow-core", "io.arrow-kt", "arrow-core").versionRef("arrow")
             library("arrow-functions", "io.arrow-kt", "arrow-functions").versionRef("arrow")
@@ -69,8 +68,6 @@ dependencyResolutionManagement {
 
             library("ktor-server-auth-jvm", "io.ktor", "ktor-server-auth-jvm").versionRef("ktor")
             library("token-validation-ktor-v3", "no.nav.security", "token-validation-ktor-v3").versionRef("token-validation-ktor")
-
-            library("emottak-utils", "no.nav.emottak", "emottak-utils").versionRef("emottak-utils")
 
             bundle("prometheus", listOf("ktor-server-metrics-micrometer", "micrometer-registry-prometheus"))
             bundle("logging", listOf("logback-classic", "logback-logstash"))

--- a/src/main/kotlin/no/nav/emottak/state/config/Config.kt
+++ b/src/main/kotlin/no/nav/emottak/state/config/Config.kt
@@ -2,7 +2,6 @@ package no.nav.emottak.state.config
 
 import com.sksamuel.hoplite.Masked
 import kotlinx.serialization.Serializable
-import no.nav.emottak.utils.config.Server
 import java.util.Properties
 import kotlin.time.Duration
 
@@ -11,6 +10,14 @@ data class Config(
     val poller: Poller,
     val database: Database
 )
+
+data class Server(
+    val port: Port,
+    val preWait: Duration
+)
+
+@JvmInline
+value class Port(val value: Int)
 
 data class Poller(
     val fetchLimit: Int,


### PR DESCRIPTION
Flyttet `Server` konfigurasjon fra `emottak-utils`.

Oppgave: https://github.com/navikt/team-emottak-docs/issues/308