### PR TITLE
Fix double launching

### DIFF
--- a/src/test/kotlin/no/nav/helsemelding/state/processor/MessageProcessorSpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/state/processor/MessageProcessorSpec.kt
@@ -37,7 +37,7 @@ class MessageProcessorSpec : StringSpec(
             messageStateService.getMessageSnapshot(uuid).shouldBeNull()
 
             val dialogMessage = DialogMessage(uuid, "data".toByteArray())
-            messageProcessor.processAndSendMessage(this, dialogMessage).join()
+            messageProcessor.processAndSendMessage(dialogMessage)
 
             val messageSnapshot = messageStateService.getMessageSnapshot(uuid)
             messageSnapshot.shouldNotBeNull()
@@ -69,7 +69,7 @@ class MessageProcessorSpec : StringSpec(
             messageStateService.getMessageSnapshot(uuid).shouldBeNull()
 
             val dialogMessage = DialogMessage(uuid, "data".toByteArray())
-            messageProcessor.processAndSendMessage(this, dialogMessage).join()
+            messageProcessor.processAndSendMessage(dialogMessage)
 
             messageStateService.getMessageSnapshot(uuid).shouldBeNull()
         }


### PR DESCRIPTION
...and clean up logging.

The code was problematic due to the following:

- `onEach { processAndSendMessage(scope, message) }` launches a new coroutine per message via `scope.launch`.
- `launchIn(scope)` already collects the flow in a coroutine, so you end up with double launching.
- It also makes backpressure/cancellation harder to reason about, and you can accidentally create a lot of concurrent jobs.

Also, since the code was never-ending the scheduler never started:


```
messageProcessor.processMessages(scope)

schedulePoller(poller) // code never reached

awaitCancellation()
```
            
