### PR TITLE
Pass in message id as argument

### DIFF
--- a/src/main/kotlin/no/nav/helsemelding/state/model/CreateState.kt
+++ b/src/main/kotlin/no/nav/helsemelding/state/model/CreateState.kt
@@ -6,8 +6,9 @@ import kotlin.time.Instant
 import kotlin.uuid.Uuid
 
 data class CreateState(
-    val messageType: MessageType,
+    val id: Uuid,
     val externalRefId: Uuid,
+    val messageType: MessageType,
     val externalMessageUrl: URL,
     val occurredAt: Instant = Clock.System.now()
 )

--- a/src/main/kotlin/no/nav/helsemelding/state/model/MessageStateSnapshot.kt
+++ b/src/main/kotlin/no/nav/helsemelding/state/model/MessageStateSnapshot.kt
@@ -2,5 +2,5 @@ package no.nav.helsemelding.state.model
 
 data class MessageStateSnapshot(
     val messageState: MessageState,
-    val messageStateChange: List<MessageStateChange>
+    val messageStateChanges: List<MessageStateChange>
 )

--- a/src/main/kotlin/no/nav/helsemelding/state/model/UpdateState.kt
+++ b/src/main/kotlin/no/nav/helsemelding/state/model/UpdateState.kt
@@ -5,8 +5,8 @@ import kotlin.time.Instant
 import kotlin.uuid.Uuid
 
 data class UpdateState(
-    val messageType: MessageType,
     val externalRefId: Uuid,
+    val messageType: MessageType,
     val oldDeliveryState: ExternalDeliveryState?,
     val newDeliveryState: ExternalDeliveryState?,
     val oldAppRecStatus: AppRecStatus?,

--- a/src/main/kotlin/no/nav/helsemelding/state/processor/MessageProcessor.kt
+++ b/src/main/kotlin/no/nav/helsemelding/state/processor/MessageProcessor.kt
@@ -62,8 +62,9 @@ class MessageProcessor(
     private suspend fun initializeState(metadata: Metadata, dialogMessageId: Uuid) {
         val snapshot = messageStateService.createInitialState(
             CreateState(
-                messageType = DIALOG,
+                id = dialogMessageId,
                 externalRefId = metadata.id,
+                messageType = DIALOG,
                 externalMessageUrl = URI.create(metadata.location).toURL()
             )
         )

--- a/src/main/kotlin/no/nav/helsemelding/state/repository/MessageStateTransactionRepository.kt
+++ b/src/main/kotlin/no/nav/helsemelding/state/repository/MessageStateTransactionRepository.kt
@@ -22,8 +22,9 @@ class ExposedMessageStateTransactionRepository(
         createState: CreateState
     ): MessageStateSnapshot = suspendTransaction(database) {
         val messageState = messageRepository.createState(
-            messageType = createState.messageType,
+            id = createState.id,
             externalRefId = createState.externalRefId,
+            messageType = createState.messageType,
             externalMessageUrl = createState.externalMessageUrl,
             lastStateChange = createState.occurredAt
         )
@@ -72,8 +73,9 @@ class FakeMessageStateTransactionRepository(
         createState: CreateState
     ): MessageStateSnapshot {
         val messageState = messageRepository.createState(
-            messageType = createState.messageType,
+            id = createState.id,
             externalRefId = createState.externalRefId,
+            messageType = createState.messageType,
             externalMessageUrl = createState.externalMessageUrl,
             lastStateChange = createState.occurredAt
         )

--- a/src/main/kotlin/no/nav/helsemelding/state/service/PollerService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/state/service/PollerService.kt
@@ -141,8 +141,8 @@ class PollerService(
         log.info { message.formatTransition(PENDING) }
         messageStateService.recordStateChange(
             UpdateState(
-                message.messageType,
                 message.externalRefId,
+                message.messageType,
                 message.externalDeliveryState,
                 newState,
                 message.appRecStatus,
@@ -159,8 +159,8 @@ class PollerService(
         log.info { message.formatTransition(COMPLETED) }
         messageStateService.recordStateChange(
             UpdateState(
-                message.messageType,
                 message.externalRefId,
+                message.messageType,
                 message.externalDeliveryState,
                 newState,
                 message.appRecStatus,
@@ -179,8 +179,8 @@ class PollerService(
         log.warn { message.formatTransition(REJECTED) }
         messageStateService.recordStateChange(
             UpdateState(
-                message.messageType,
                 message.externalRefId,
+                message.messageType,
                 message.externalDeliveryState,
                 newState,
                 message.appRecStatus,

--- a/src/main/resources/db/migration/V1__create_messages_table.sql
+++ b/src/main/resources/db/migration/V1__create_messages_table.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS messages
 (
-    id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    id                    UUID                     PRIMARY KEY,
     message_type          VARCHAR(100)             NOT NULL,
     external_reference_id UUID                     NOT NULL UNIQUE,
     external_message_url  TEXT                     NOT NULL UNIQUE,

--- a/src/test/kotlin/no/nav/helsemelding/state/repository/MessageRepositorySpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/state/repository/MessageRepositorySpec.kt
@@ -50,13 +50,15 @@ class MessageRepositorySpec : StringSpec(
                 suspendTransaction(database) {
                     val messageRepository = ExposedMessageRepository(database)
 
+                    val id = Uuid.random()
                     val externalRefId = Uuid.random()
                     val externalMessageUrl = URI.create(MESSAGE1).toURL()
                     val now = Clock.System.now()
 
                     val state = messageRepository.createState(
-                        messageType = DIALOG,
+                        id,
                         externalRefId = externalRefId,
+                        messageType = DIALOG,
                         externalMessageUrl = externalMessageUrl,
                         lastStateChange = now
                     )
@@ -79,12 +81,14 @@ class MessageRepositorySpec : StringSpec(
                 suspendTransaction(database) {
                     val messageRepository = ExposedMessageRepository(database)
 
+                    val id = Uuid.random()
                     val externalRefId = Uuid.random()
                     val externalMessageUrl = URI.create(MESSAGE1).toURL()
 
                     messageRepository.createState(
-                        messageType = DIALOG,
+                        id = id,
                         externalRefId = externalRefId,
+                        messageType = DIALOG,
                         externalMessageUrl = externalMessageUrl,
                         lastStateChange = Clock.System.now()
                     )
@@ -122,12 +126,14 @@ class MessageRepositorySpec : StringSpec(
                 suspendTransaction(database) {
                     val messageRepository = ExposedMessageRepository(database)
 
+                    val id = Uuid.random()
                     val externalRefId = Uuid.random()
                     val externalMessageUrl = URI.create(MESSAGE1).toURL()
 
                     messageRepository.createState(
-                        messageType = DIALOG,
+                        id = id,
                         externalRefId = externalRefId,
+                        messageType = DIALOG,
                         externalMessageUrl = externalMessageUrl,
                         lastStateChange = Clock.System.now()
                     )
@@ -167,15 +173,17 @@ class MessageRepositorySpec : StringSpec(
                     val messageRepository = ExposedMessageRepository(database)
 
                     messageRepository.createState(
-                        DIALOG,
                         Uuid.random(),
+                        Uuid.random(),
+                        DIALOG,
                         URI.create(MESSAGE1).toURL(),
                         Clock.System.now()
                     )
 
                     messageRepository.createState(
-                        DIALOG,
                         Uuid.random(),
+                        Uuid.random(),
+                        DIALOG,
                         URI.create(MESSAGE2).toURL(),
                         Clock.System.now()
                     )
@@ -186,8 +194,9 @@ class MessageRepositorySpec : StringSpec(
                         }
 
                     messageRepository.createState(
-                        DIALOG,
                         Uuid.random(),
+                        Uuid.random(),
+                        DIALOG,
                         URI.create(MESSAGE3).toURL(),
                         Clock.System.now()
                     )
@@ -198,8 +207,9 @@ class MessageRepositorySpec : StringSpec(
                         }
 
                     messageRepository.createState(
-                        DIALOG,
                         Uuid.random(),
+                        Uuid.random(),
+                        DIALOG,
                         URI.create(MESSAGE4).toURL(),
                         Clock.System.now()
                     )
@@ -211,8 +221,9 @@ class MessageRepositorySpec : StringSpec(
                         }
 
                     messageRepository.createState(
-                        DIALOG,
                         Uuid.random(),
+                        Uuid.random(),
+                        DIALOG,
                         URI.create(MESSAGE5).toURL(),
                         Clock.System.now()
                     )
@@ -235,11 +246,26 @@ class MessageRepositorySpec : StringSpec(
                     val messageRepository = ExposedMessageRepository(database)
                     val now = Clock.System.now()
 
+                    val oldId = Uuid.random()
+                    val newId = Uuid.random()
                     val oldExternalRefId = Uuid.random()
                     val newExternalRefId = Uuid.random()
 
-                    messageRepository.createState(DIALOG, oldExternalRefId, URI.create(MESSAGE1).toURL(), now)
-                    messageRepository.createState(DIALOG, newExternalRefId, URI.create(MESSAGE2).toURL(), now)
+                    messageRepository.createState(
+                        oldId,
+                        oldExternalRefId,
+                        DIALOG,
+                        URI.create(MESSAGE1).toURL(),
+                        now
+                    )
+
+                    messageRepository.createState(
+                        newId,
+                        newExternalRefId,
+                        DIALOG,
+                        URI.create(MESSAGE2).toURL(),
+                        now
+                    )
 
                     Messages.update({ externalRefId eq oldExternalRefId }) {
                         it[lastPolledAt] = now - Duration.parse("31s")
@@ -264,19 +290,34 @@ class MessageRepositorySpec : StringSpec(
                     val messageRepository = ExposedMessageRepository(database)
                     val now = Clock.System.now()
 
-                    val never = Uuid.random()
-                    val recent = Uuid.random()
+                    val neverId = Uuid.random()
+                    val recentId = Uuid.random()
+                    val neverExternalRefId = Uuid.random()
+                    val recentExternalRefId = Uuid.random()
 
-                    messageRepository.createState(DIALOG, never, URI.create(MESSAGE1).toURL(), now)
-                    messageRepository.createState(DIALOG, recent, URI.create(MESSAGE2).toURL(), now)
+                    messageRepository.createState(
+                        neverId,
+                        neverExternalRefId,
+                        DIALOG,
+                        URI.create(MESSAGE1).toURL(),
+                        now
+                    )
 
-                    Messages.update({ externalRefId eq recent }) {
+                    messageRepository.createState(
+                        recentId,
+                        recentExternalRefId,
+                        DIALOG,
+                        URI.create(MESSAGE2).toURL(),
+                        now
+                    )
+
+                    Messages.update({ externalRefId eq recentExternalRefId }) {
                         it[lastPolledAt] = now
                     }
 
                     val externalRefIds = messageRepository.findForPolling().map { it.externalRefId }
-                    externalRefIds shouldContain never
-                    externalRefIds shouldNotContain recent
+                    externalRefIds shouldContain neverExternalRefId
+                    externalRefIds shouldNotContain recentExternalRefId
                 }
             }
         }
@@ -288,14 +329,37 @@ class MessageRepositorySpec : StringSpec(
                 suspendTransaction(database) {
                     val messageRepository = ExposedMessageRepository(database)
 
+                    val id1 = Uuid.random()
+                    val id2 = Uuid.random()
+                    val id3 = Uuid.random()
                     val externalRefId1 = Uuid.random()
                     val externalRefId2 = Uuid.random()
                     val externalRefId3 = Uuid.random()
                     val now = Clock.System.now()
 
-                    messageRepository.createState(DIALOG, externalRefId1, URI.create(MESSAGE1).toURL(), now)
-                    messageRepository.createState(DIALOG, externalRefId2, URI.create(MESSAGE2).toURL(), now)
-                    messageRepository.createState(DIALOG, externalRefId3, URI.create(MESSAGE3).toURL(), now)
+                    messageRepository.createState(
+                        id1,
+                        externalRefId1,
+                        DIALOG,
+                        URI.create(MESSAGE1).toURL(),
+                        now
+                    )
+
+                    messageRepository.createState(
+                        id2,
+                        externalRefId2,
+                        DIALOG,
+                        URI.create(MESSAGE2).toURL(),
+                        now
+                    )
+
+                    messageRepository.createState(
+                        id3,
+                        externalRefId3,
+                        DIALOG,
+                        URI.create(MESSAGE3).toURL(),
+                        now
+                    )
 
                     messageRepository.markPolled(listOf(externalRefId1, externalRefId2)) shouldBe 2
 

--- a/src/test/kotlin/no/nav/helsemelding/state/repository/MessageStateHistoryRepositorySpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/state/repository/MessageStateHistoryRepositorySpec.kt
@@ -64,13 +64,15 @@ class MessageStateHistoryRepositorySpec : StringSpec(
                     val messageRepository = ExposedMessageRepository(database)
                     val messageStateHistoryRepository = ExposedMessageStateHistoryRepository(database)
 
+                    val id = Uuid.random()
                     val externalRefId = Uuid.random()
                     val externalMessageUrl = URI.create(MESSAGE).toURL()
                     val occurredAt = Clock.System.now()
 
                     messageRepository.createState(
-                        messageType = DIALOG,
+                        id = id,
                         externalRefId = externalRefId,
+                        messageType = DIALOG,
                         externalMessageUrl = externalMessageUrl,
                         lastStateChange = occurredAt
                     )
@@ -104,11 +106,18 @@ class MessageStateHistoryRepositorySpec : StringSpec(
                     val messageRepository = ExposedMessageRepository(database)
                     val messageStateHistoryRepository = ExposedMessageStateHistoryRepository(database)
 
+                    val id = Uuid.random()
                     val externalRefId = Uuid.random()
                     val externalMessageUrl = URI.create(MESSAGE).toURL()
                     val now = Clock.System.now()
 
-                    messageRepository.createState(DIALOG, externalRefId, externalMessageUrl, now)
+                    messageRepository.createState(
+                        id,
+                        externalRefId,
+                        DIALOG,
+                        externalMessageUrl,
+                        now
+                    )
 
                     messageStateHistoryRepository.append(
                         messageId = externalRefId,
@@ -159,11 +168,18 @@ class MessageStateHistoryRepositorySpec : StringSpec(
                     val messageRepository = ExposedMessageRepository(database)
                     val messageStateHistoryRepository = ExposedMessageStateHistoryRepository(database)
 
+                    val id = Uuid.random()
                     val externalRefId = Uuid.random()
                     val externalMessageUrl = URI.create(MESSAGE).toURL()
                     val now = Clock.System.now()
 
-                    messageRepository.createState(DIALOG, externalRefId, externalMessageUrl, now)
+                    messageRepository.createState(
+                        id,
+                        externalRefId,
+                        DIALOG,
+                        externalMessageUrl,
+                        now
+                    )
 
                     messageStateHistoryRepository.append(
                         externalRefId,

--- a/src/test/kotlin/no/nav/helsemelding/state/repository/MessageStateTransactionRepositorySpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/state/repository/MessageStateTransactionRepositorySpec.kt
@@ -37,37 +37,40 @@ class MessageStateTransactionRepositorySpec : StringSpec(
                     ExposedMessageStateHistoryRepository(database)
                 )
 
+                val id = Uuid.random()
                 val externalRefId = Uuid.random()
                 val url = URI.create(MESSAGE).toURL()
                 val now = Clock.System.now()
 
-                val snapshot = messageStateTransactionRepository.createInitialState(
+                val messageStateSnapshot = messageStateTransactionRepository.createInitialState(
                     CreateState(
-                        messageType = DIALOG,
+                        id = id,
                         externalRefId = externalRefId,
+                        messageType = DIALOG,
                         externalMessageUrl = url,
                         occurredAt = now
                     )
                 )
 
-                val messageState = snapshot.messageState
+                val messageState = messageStateSnapshot.messageState
 
-                messageState.messageType shouldBe DIALOG
+                messageState.id shouldBe id
                 messageState.externalRefId shouldBe externalRefId
+                messageState.messageType shouldBe DIALOG
                 messageState.externalMessageUrl shouldBe url
 
                 messageState.externalDeliveryState shouldBe null
                 messageState.appRecStatus shouldBe null
 
-                snapshot.messageStateChange.size shouldBe 1
-                val entry = snapshot.messageStateChange.first()
+                messageStateSnapshot.messageStateChanges.size shouldBe 1
+                val messageStateChange = messageStateSnapshot.messageStateChanges.first()
 
-                entry.messageId shouldBe externalRefId
-                entry.oldDeliveryState shouldBe null
-                entry.newDeliveryState shouldBe null
-                entry.oldAppRecStatus shouldBe null
-                entry.newAppRecStatus shouldBe null
-                entry.changedAt shouldBeInstant now
+                messageStateChange.messageId shouldBe externalRefId
+                messageStateChange.oldDeliveryState shouldBe null
+                messageStateChange.newDeliveryState shouldBe null
+                messageStateChange.oldAppRecStatus shouldBe null
+                messageStateChange.newAppRecStatus shouldBe null
+                messageStateChange.changedAt shouldBeInstant now
             }
         }
 
@@ -81,23 +84,25 @@ class MessageStateTransactionRepositorySpec : StringSpec(
                     ExposedMessageStateHistoryRepository(database)
                 )
 
+                val id = Uuid.random()
                 val externalRefId = Uuid.random()
                 val externalMessageUrl = URI.create(MESSAGE).toURL()
                 val now = Clock.System.now()
 
                 messageStateTransactionRepository.createInitialState(
                     CreateState(
-                        messageType = DIALOG,
+                        id = id,
                         externalRefId = externalRefId,
+                        messageType = DIALOG,
                         externalMessageUrl = externalMessageUrl,
                         occurredAt = now
                     )
                 )
 
-                val snapshot = messageStateTransactionRepository.recordStateChange(
+                val messageStateSnapshot = messageStateTransactionRepository.recordStateChange(
                     UpdateState(
-                        messageType = DIALOG,
                         externalRefId = externalRefId,
+                        messageType = DIALOG,
                         oldDeliveryState = null,
                         newDeliveryState = ACKNOWLEDGED,
                         oldAppRecStatus = null,
@@ -106,18 +111,18 @@ class MessageStateTransactionRepositorySpec : StringSpec(
                     )
                 )
 
-                snapshot.messageStateChange.size shouldBe 2
+                messageStateSnapshot.messageStateChanges.size shouldBe 2
 
-                val entry = snapshot.messageStateChange.last()
+                val messageStateChange = messageStateSnapshot.messageStateChanges.last()
 
-                entry.messageId shouldBe externalRefId
-                entry.oldDeliveryState shouldBe null
-                entry.newDeliveryState shouldBe ACKNOWLEDGED
+                messageStateChange.messageId shouldBe externalRefId
+                messageStateChange.oldDeliveryState shouldBe null
+                messageStateChange.newDeliveryState shouldBe ACKNOWLEDGED
 
-                entry.oldAppRecStatus shouldBe null
-                entry.newAppRecStatus shouldBe null
+                messageStateChange.oldAppRecStatus shouldBe null
+                messageStateChange.newAppRecStatus shouldBe null
 
-                entry.changedAt shouldBeInstant now
+                messageStateChange.changedAt shouldBeInstant now
             }
         }
 


### PR DESCRIPTION
A random generated message id don't bring any real value so instead we are passing in the message id. In all cases this will be the kafka key from the consumed messages. This bridges what our clients are sending us with what we are tracking. Effectively meaning we can pass back messages on incoming topics using the same key as reference point. Issue [38](https://github.com/navikt/helsemelding-state-service/issues/38)