### PR TITLE
Gitt helsemelding-kafka-manager lesetilgang til kafka topicene

### DIFF
--- a/.nais/kafka/kafka-dev.yaml
+++ b/.nais/kafka/kafka-dev.yaml
@@ -24,7 +24,7 @@ spec:
       application: message-generator
       team: helsemelding
     - access: read
-      application: helsemelding-kafka-manager
+      application: kafka-manager
       team: helsemelding
 
 ---
@@ -52,7 +52,7 @@ spec:
       application: state-service
       team: helsemelding
     - access: read
-      application: helsemelding-kafka-manager
+      application: kafka-manager
       team: helsemelding
 
 ---
@@ -80,5 +80,5 @@ spec:
       application: state-service
       team: helsemelding
     - access: read
-      application: helsemelding-kafka-manager
+      application: kafka-manager
       team: helsemelding


### PR DESCRIPTION
Jeg har satt opp [vår egen Kafka Manager](https://helsemelding-kafka-manager.intern.dev.nav.no/index.html).

Oppgave: https://github.com/navikt/helsemelding-issues/issues/3