### PR TITLE
Separate on rejection types

### DIFF
--- a/src/main/kotlin/no/nav/helsemelding/state/evaluator/StateTransitionEvaluator.kt
+++ b/src/main/kotlin/no/nav/helsemelding/state/evaluator/StateTransitionEvaluator.kt
@@ -6,6 +6,7 @@ import no.nav.helsemelding.state.model.DeliveryEvaluationState
 import no.nav.helsemelding.state.model.isNotAcknowledged
 import no.nav.helsemelding.state.model.isNotNull
 import no.nav.helsemelding.state.model.resolveDelivery
+import no.nav.helsemelding.state.model.toDeliveryState
 
 /**
  * Evaluates whether a transition between two **multi-axis delivery states**
@@ -125,6 +126,6 @@ class StateTransitionEvaluator(
         val oldResolved = old.resolveDelivery()
         val newResolved = new.resolveDelivery()
 
-        with(transportValidator) { evaluate(oldResolved.state, newResolved.state) }
+        with(transportValidator) { evaluate(oldResolved.toDeliveryState(), newResolved.toDeliveryState()) }
     }
 }

--- a/src/main/kotlin/no/nav/helsemelding/state/model/DeliveryResolution.kt
+++ b/src/main/kotlin/no/nav/helsemelding/state/model/DeliveryResolution.kt
@@ -1,6 +1,0 @@
-package no.nav.helsemelding.state.model
-
-data class DeliveryResolution(
-    val state: MessageDeliveryState,
-    val pendingReason: PendingReason? = null
-)

--- a/src/main/kotlin/no/nav/helsemelding/state/model/NextStateDecision.kt
+++ b/src/main/kotlin/no/nav/helsemelding/state/model/NextStateDecision.kt
@@ -5,7 +5,15 @@ sealed interface NextStateDecision {
         override fun toString() = "UNCHANGED"
     }
 
-    data class Transition(val to: MessageDeliveryState) : NextStateDecision {
-        override fun toString() = to.name
+    data class Transition(val to: MessageDeliveryState) : NextStateDecision
+
+    sealed interface Rejected : NextStateDecision {
+        data object Transport : Rejected {
+            override fun toString() = "TRANSPORT_REJECTED"
+        }
+
+        data object AppRec : Rejected {
+            override fun toString() = "APP_REC_REJECTED"
+        }
     }
 }

--- a/src/main/kotlin/no/nav/helsemelding/state/service/StateEvaluatorService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/state/service/StateEvaluatorService.kt
@@ -38,11 +38,11 @@ class StateEvaluatorService(
     ): NextStateDecision =
         with(transitionValidator) {
             evaluate(old, new)
-            val oldResolvedState = old.resolveDelivery().state
-            val newResolvedState = new.resolveDelivery().state
+            val oldResolvedDelivery = old.resolveDelivery()
+            val newResolvedDelivery = new.resolveDelivery()
 
-            if (oldResolvedState != newResolvedState) {
-                NextStateDecision.Transition(newResolvedState)
+            if (oldResolvedDelivery != newResolvedDelivery) {
+                newResolvedDelivery.decision
             } else {
                 NextStateDecision.Unchanged
             }

--- a/src/test/kotlin/no/nav/helsemelding/state/model/DeliveryEvaluationStateSpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/state/model/DeliveryEvaluationStateSpec.kt
@@ -8,7 +8,6 @@ import no.nav.helsemelding.state.model.MessageDeliveryState.COMPLETED
 import no.nav.helsemelding.state.model.MessageDeliveryState.INVALID
 import no.nav.helsemelding.state.model.MessageDeliveryState.NEW
 import no.nav.helsemelding.state.model.MessageDeliveryState.PENDING
-import no.nav.helsemelding.state.model.MessageDeliveryState.REJECTED
 import no.nav.helsemelding.state.model.TransportStatus.ACKNOWLEDGED
 
 class DeliveryEvaluationStateSpec : StringSpec(
@@ -20,31 +19,61 @@ class DeliveryEvaluationStateSpec : StringSpec(
             )
 
         "NEW transport + null apprec → NEW" {
-            toDelivery(TransportStatus.NEW, null).resolveDelivery().state shouldBe NEW
+            toDelivery(TransportStatus.NEW, null).resolveDelivery().decision shouldBe
+                NextStateDecision.Transition(NEW)
+
+            toDelivery(TransportStatus.NEW, null).resolveDelivery().pendingReason shouldBe null
         }
 
-        "ACK transport + null apprec → PENDING" {
-            toDelivery(ACKNOWLEDGED, null).resolveDelivery().state shouldBe PENDING
+        "PENDING transport + null apprec → PENDING(WAITING_FOR_TRANSPORT_ACKNOWLEDGEMENT)" {
+            toDelivery(TransportStatus.PENDING, null).resolveDelivery().decision shouldBe
+                NextStateDecision.Transition(PENDING)
+
+            toDelivery(TransportStatus.PENDING, null).resolveDelivery().pendingReason shouldBe
+                PendingReason.WAITING_FOR_TRANSPORT_ACKNOWLEDGEMENT
+        }
+
+        "ACK transport + null apprec → PENDING(WAITING_FOR_APPREC)" {
+            toDelivery(ACKNOWLEDGED, null).resolveDelivery().decision shouldBe
+                NextStateDecision.Transition(PENDING)
+
+            toDelivery(ACKNOWLEDGED, null).resolveDelivery().pendingReason shouldBe
+                PendingReason.WAITING_FOR_APPREC
         }
 
         "ACK transport + OK apprec → COMPLETED" {
-            toDelivery(ACKNOWLEDGED, OK).resolveDelivery().state shouldBe COMPLETED
+            toDelivery(ACKNOWLEDGED, OK).resolveDelivery().decision shouldBe
+                NextStateDecision.Transition(COMPLETED)
+
+            toDelivery(ACKNOWLEDGED, OK).resolveDelivery().pendingReason shouldBe null
         }
 
         "ACK transport + OK_ERROR_IN_MESSAGE_PART apprec → COMPLETED" {
-            toDelivery(ACKNOWLEDGED, OK_ERROR_IN_MESSAGE_PART).resolveDelivery().state shouldBe COMPLETED
+            toDelivery(ACKNOWLEDGED, OK_ERROR_IN_MESSAGE_PART).resolveDelivery().decision shouldBe
+                NextStateDecision.Transition(COMPLETED)
+
+            toDelivery(ACKNOWLEDGED, OK_ERROR_IN_MESSAGE_PART).resolveDelivery().pendingReason shouldBe null
         }
 
-        "ACK transport + REJECTED apprec → REJECTED" {
-            toDelivery(ACKNOWLEDGED, AppRecStatus.REJECTED).resolveDelivery().state shouldBe REJECTED
+        "ACK transport + REJECTED apprec → REJECTED_APPREC" {
+            toDelivery(ACKNOWLEDGED, AppRecStatus.REJECTED).resolveDelivery().decision shouldBe
+                NextStateDecision.Rejected.AppRec
+
+            toDelivery(ACKNOWLEDGED, AppRecStatus.REJECTED).resolveDelivery().pendingReason shouldBe null
         }
 
-        "REJECTED transport + null apprec → REJECTED" {
-            toDelivery(TransportStatus.REJECTED, null).resolveDelivery().state shouldBe REJECTED
+        "REJECTED transport + null apprec → REJECTED_TRANSPORT" {
+            toDelivery(TransportStatus.REJECTED, null).resolveDelivery().decision shouldBe
+                NextStateDecision.Rejected.Transport
+
+            toDelivery(TransportStatus.REJECTED, null).resolveDelivery().pendingReason shouldBe null
         }
 
         "INVALID transport + null apprec → INVALID" {
-            toDelivery(TransportStatus.INVALID, null).resolveDelivery().state shouldBe INVALID
+            toDelivery(TransportStatus.INVALID, null).resolveDelivery().decision shouldBe
+                NextStateDecision.Transition(INVALID)
+
+            toDelivery(TransportStatus.INVALID, null).resolveDelivery().pendingReason shouldBe null
         }
     }
 )


### PR DESCRIPTION
We need to separate on the specific `REJECTED` types since we will publish rejections to Kafka with different formats.