### PR TITLE
Separate on pending types

### DIFF
--- a/src/main/kotlin/no/nav/helsemelding/state/model/DeliveryEvaluationState.kt
+++ b/src/main/kotlin/no/nav/helsemelding/state/model/DeliveryEvaluationState.kt
@@ -1,6 +1,12 @@
 package no.nav.helsemelding.state.model
 
-import no.nav.helsemelding.state.model.NextStateDecision.Transition
+import no.nav.helsemelding.state.model.MessageDeliveryState.COMPLETED
+import no.nav.helsemelding.state.model.MessageDeliveryState.INVALID
+import no.nav.helsemelding.state.model.MessageDeliveryState.NEW
+import no.nav.helsemelding.state.model.NextStateDecision.Pending.AppRec
+import no.nav.helsemelding.state.model.NextStateDecision.Pending.Transport
+import no.nav.helsemelding.state.model.PendingReason.WAITING_FOR_APPREC
+import no.nav.helsemelding.state.model.PendingReason.WAITING_FOR_TRANSPORT_ACKNOWLEDGEMENT
 
 data class DeliveryEvaluationState(
     val transport: TransportStatus,
@@ -14,37 +20,37 @@ data class DeliveryResolution(
 
 fun DeliveryEvaluationState.resolveDelivery(): DeliveryResolution =
     when (transport) {
-        TransportStatus.NEW -> DeliveryResolution(Transition(MessageDeliveryState.NEW))
-
-        TransportStatus.PENDING ->
-            DeliveryResolution(
-                decision = Transition(MessageDeliveryState.PENDING),
-                pendingReason = PendingReason.WAITING_FOR_TRANSPORT_ACKNOWLEDGEMENT
-            )
+        TransportStatus.NEW -> DeliveryResolution(NextStateDecision.Transition(NEW))
+        TransportStatus.PENDING -> DeliveryResolution(
+            decision = Transport,
+            pendingReason = WAITING_FOR_TRANSPORT_ACKNOWLEDGEMENT
+        )
 
         TransportStatus.ACKNOWLEDGED ->
             when {
-                appRec.isNull() ->
-                    DeliveryResolution(
-                        decision = Transition(MessageDeliveryState.PENDING),
-                        pendingReason = PendingReason.WAITING_FOR_APPREC
-                    )
+                appRec.isNull() -> DeliveryResolution(
+                    decision = AppRec,
+                    pendingReason = WAITING_FOR_APPREC
+                )
 
                 appRec.isRejected() -> DeliveryResolution(NextStateDecision.Rejected.AppRec)
+                appRec.isOk() || appRec.isOkErrorInMessagePart() -> DeliveryResolution(
+                    NextStateDecision.Transition(
+                        COMPLETED
+                    )
+                )
 
-                appRec.isOk() || appRec.isOkErrorInMessagePart() ->
-                    DeliveryResolution(Transition(MessageDeliveryState.COMPLETED))
-
-                else -> DeliveryResolution(Transition(MessageDeliveryState.PENDING))
+                else -> error("ACKNOWLEDGED transport but appRec was neither null/rejected/ok: $appRec")
             }
 
         TransportStatus.REJECTED -> DeliveryResolution(NextStateDecision.Rejected.Transport)
-        TransportStatus.INVALID -> DeliveryResolution(Transition(MessageDeliveryState.INVALID))
+        TransportStatus.INVALID -> DeliveryResolution(NextStateDecision.Transition(INVALID))
     }
 
 fun DeliveryResolution.toDeliveryState(): MessageDeliveryState =
     when (decision) {
-        is Transition -> decision.to
+        is NextStateDecision.Transition -> decision.to
+        is NextStateDecision.Pending -> MessageDeliveryState.PENDING
         is NextStateDecision.Rejected -> MessageDeliveryState.REJECTED
         NextStateDecision.Unchanged -> error("Unchanged is not a resolvable delivery state")
     }

--- a/src/main/kotlin/no/nav/helsemelding/state/model/MessageState.kt
+++ b/src/main/kotlin/no/nav/helsemelding/state/model/MessageState.kt
@@ -1,5 +1,6 @@
 package no.nav.helsemelding.state.model
 
+import no.nav.helsemelding.state.model.NextStateDecision.Transition
 import java.net.URL
 import kotlin.time.Instant
 import kotlin.uuid.Uuid
@@ -21,7 +22,9 @@ fun MessageState.formatUnchanged(): String = "${logPrefix()} No state transition
 
 fun MessageState.formatNew(): String = "${logPrefix()} Initial internal state: NEW (no external status received yet)"
 
-fun MessageState.formatTransition(to: MessageDeliveryState): String = "${logPrefix()} → $to"
+fun MessageState.formatTransition(to: NextStateDecision): String = "${logPrefix()} Transition → $to"
+
+fun MessageState.formatTransition(to: MessageDeliveryState): String = formatTransition(Transition(to))
 
 fun MessageState.formatInvalidState(): String = "${logPrefix()} Entered INVALID state"
 

--- a/src/main/kotlin/no/nav/helsemelding/state/model/NextStateDecision.kt
+++ b/src/main/kotlin/no/nav/helsemelding/state/model/NextStateDecision.kt
@@ -9,6 +9,16 @@ sealed interface NextStateDecision {
         override fun toString() = "TRANSITION($to)"
     }
 
+    sealed interface Pending : NextStateDecision {
+        data object Transport : Pending {
+            override fun toString() = "PENDING(TRANSPORT)"
+        }
+
+        data object AppRec : Pending {
+            override fun toString() = "PENDING(APPREC)"
+        }
+    }
+
     sealed interface Rejected : NextStateDecision {
         data object Transport : Rejected {
             override fun toString() = "REJECTED(TRANSPORT)"

--- a/src/test/kotlin/no/nav/helsemelding/state/model/DeliveryEvaluationStateSpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/state/model/DeliveryEvaluationStateSpec.kt
@@ -7,7 +7,6 @@ import no.nav.helsemelding.state.model.AppRecStatus.OK_ERROR_IN_MESSAGE_PART
 import no.nav.helsemelding.state.model.MessageDeliveryState.COMPLETED
 import no.nav.helsemelding.state.model.MessageDeliveryState.INVALID
 import no.nav.helsemelding.state.model.MessageDeliveryState.NEW
-import no.nav.helsemelding.state.model.MessageDeliveryState.PENDING
 import no.nav.helsemelding.state.model.TransportStatus.ACKNOWLEDGED
 
 class DeliveryEvaluationStateSpec : StringSpec(
@@ -27,7 +26,7 @@ class DeliveryEvaluationStateSpec : StringSpec(
 
         "PENDING transport + null apprec → PENDING(WAITING_FOR_TRANSPORT_ACKNOWLEDGEMENT)" {
             toDelivery(TransportStatus.PENDING, null).resolveDelivery().decision shouldBe
-                NextStateDecision.Transition(PENDING)
+                NextStateDecision.Pending.Transport
 
             toDelivery(TransportStatus.PENDING, null).resolveDelivery().pendingReason shouldBe
                 PendingReason.WAITING_FOR_TRANSPORT_ACKNOWLEDGEMENT
@@ -35,7 +34,7 @@ class DeliveryEvaluationStateSpec : StringSpec(
 
         "ACK transport + null apprec → PENDING(WAITING_FOR_APPREC)" {
             toDelivery(ACKNOWLEDGED, null).resolveDelivery().decision shouldBe
-                NextStateDecision.Transition(PENDING)
+                NextStateDecision.Pending.AppRec
 
             toDelivery(ACKNOWLEDGED, null).resolveDelivery().pendingReason shouldBe
                 PendingReason.WAITING_FOR_APPREC

--- a/src/test/kotlin/no/nav/helsemelding/state/service/StateEvaluatorServiceSpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/state/service/StateEvaluatorServiceSpec.kt
@@ -19,6 +19,7 @@ import no.nav.helsemelding.state.model.MessageDeliveryState.PENDING
 import no.nav.helsemelding.state.model.MessageDeliveryState.REJECTED
 import no.nav.helsemelding.state.model.MessageState
 import no.nav.helsemelding.state.model.MessageType.DIALOG
+import no.nav.helsemelding.state.model.NextStateDecision.Pending
 import no.nav.helsemelding.state.model.NextStateDecision.Transition
 import no.nav.helsemelding.state.model.NextStateDecision.Unchanged
 import no.nav.helsemelding.state.model.TransportStatus
@@ -114,11 +115,18 @@ class StateEvaluatorServiceSpec : StringSpec(
             either { with(service) { determineNextState(old, new) } } shouldBe Right(Unchanged)
         }
 
-        "determineNextState -> new resolved state on valid transition (NEW -> PENDING)" {
+        "determineNextState -> new resolved state on valid transition (NEW -> PENDING(TRANSPORT))" {
             val old = DeliveryEvaluationState(transport = TransportStatus.NEW, appRec = null)
             val new = DeliveryEvaluationState(transport = TransportStatus.PENDING, appRec = null)
 
-            either { with(service) { determineNextState(old, new) } } shouldBe Right(Transition(PENDING))
+            either { with(service) { determineNextState(old, new) } } shouldBe Right(Pending.Transport)
+        }
+
+        "determineNextState -> new resolved state on valid transition (NEW -> PENDING(APPREC))" {
+            val old = DeliveryEvaluationState(transport = TransportStatus.NEW, appRec = null)
+            val new = DeliveryEvaluationState(transport = TransportStatus.ACKNOWLEDGED, appRec = null)
+
+            either { with(service) { determineNextState(old, new) } } shouldBe Right(Pending.AppRec)
         }
 
         "determineNextState -> new resolved state on valid transition (PENDING -> COMPLETED)" {


### PR DESCRIPTION
This is mainly for logging and tracking purposes. Are we waiting for `TRANSPORT` status or `APPREC` status ? Later on we might change what we publish to Kafka, ie the event stream approach, and then we also need to separate on the actual event type.