### PR TITLE
Introduce usage of cross batch parallelism

### DIFF
--- a/src/main/kotlin/no/nav/helsemelding/outbound/service/PollerService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/service/PollerService.kt
@@ -72,7 +72,7 @@ class PollerService(
                 .withLogging()
                 .takeIf { it.isNotEmpty() }
                 ?.chunked(pollerConfig.batchSize)
-                ?.forEach { processBatch(it) }
+                ?.parMap(Dispatchers.IO) { batch -> processBatch(batch) }
         }
 
         log.info { "=== Poll cycle end: ${duration.inWholeMilliseconds}ms ===" }
@@ -83,7 +83,7 @@ class PollerService(
         log.info { "Processing ($summary)" }
 
         logBatchDuration(summary) {
-            batch.parMap(Dispatchers.IO) { pollAndProcessMessage(it) }
+            batch.forEach { pollAndProcessMessage(it) }
 
             val marked = messageStateService.markAsPolled(batch.map { it.externalRefId })
             log.debug { "Marked as polled (count=$marked, $summary)" }


### PR DESCRIPTION
By moving the parallelism up from inner batch to cross batch - parallelism we have a more scalable service. If we later on decide that we need maximum performance we can do both.