### PR TITLE
Add back oid to apprec errors

### DIFF
--- a/src/main/kotlin/no/nav/helsemelding/outbound/model/AppRecErrorMessage.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/model/AppRecErrorMessage.kt
@@ -5,5 +5,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class AppRecErrorMessage(
     val code: String? = null,
-    val text: String? = null
+    val description: String? = null,
+    val oid: String? = null
 )

--- a/src/main/kotlin/no/nav/helsemelding/outbound/service/PollerService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/service/PollerService.kt
@@ -286,7 +286,8 @@ class PollerService(
             errorList = appRecErrorList.orEmpty().map {
                 AppRecErrorMessage(
                     code = it.errorCode,
-                    text = it.description
+                    description = it.description,
+                    oid = it.oid
                 )
             }
         )


### PR DESCRIPTION
This was accidentally removed by the latest PR and has now been added back. Also the variable naming has been aligned.