### PR TITLE
Add error topic

### DIFF
--- a/.nais/kafka/kafka-dev.yaml
+++ b/.nais/kafka/kafka-dev.yaml
@@ -82,3 +82,31 @@ spec:
     - access: read
       application: kafka-manager
       team: helsemelding
+
+---
+
+apiVersion: kafka.nais.io/v1
+kind: Topic
+metadata:
+  labels:
+    team: helsemelding
+  name: dialog.out.error
+  namespace: helsemelding
+spec:
+  pool: nav-dev
+  config:
+    cleanupPolicy: delete
+    maxMessageBytes: 1048588
+    minimumInSyncReplicas: 2
+    partitions: 1
+    replication: 3
+    retentionBytes: -1
+    retentionHours: 168
+    segmentHours: 168
+  acl:
+    - access: write
+      application: outbound-message-service
+      team: helsemelding
+    - access: read
+      application: kafka-manager
+      team: helsemelding

--- a/src/main/kotlin/no/nav/helsemelding/outbound/App.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/App.kt
@@ -5,6 +5,7 @@ import arrow.continuations.ktor.server
 import arrow.core.raise.result
 import arrow.fx.coroutines.resourceScope
 import arrow.resilience.Schedule
+import io.github.nomisRev.kafka.publisher.KafkaPublisher
 import io.github.nomisRev.kafka.receiver.KafkaReceiver
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.server.application.Application
@@ -17,11 +18,13 @@ import no.nav.helsemelding.outbound.evaluator.AppRecTransitionEvaluator
 import no.nav.helsemelding.outbound.evaluator.StateTransitionEvaluator
 import no.nav.helsemelding.outbound.evaluator.TransportStatusTranslator
 import no.nav.helsemelding.outbound.evaluator.TransportTransitionEvaluator
+import no.nav.helsemelding.outbound.handler.MessageErrorHandler
 import no.nav.helsemelding.outbound.metrics.CustomMetrics
 import no.nav.helsemelding.outbound.metrics.Metrics
 import no.nav.helsemelding.outbound.plugin.configureMetrics
 import no.nav.helsemelding.outbound.plugin.configureRoutes
 import no.nav.helsemelding.outbound.processor.MessageProcessor
+import no.nav.helsemelding.outbound.publisher.errorMessagePublisher
 import no.nav.helsemelding.outbound.publisher.statusMessagePublisher
 import no.nav.helsemelding.outbound.receiver.MessageReceiver
 import no.nav.helsemelding.outbound.repository.ExposedMessageRepository
@@ -62,7 +65,7 @@ fun main() = SuspendApp {
             )
 
             val messageProcessor = MessageProcessor(
-                messageReceiver = messageReceiver(deps.kafkaReceiver, metrics),
+                messageReceiver = messageReceiver(deps.kafkaReceiver, deps.kafkaPublisher, metrics),
                 messageLifecycleService = messageLifecycleService,
                 metrics = metrics
             )
@@ -163,6 +166,14 @@ private fun metricsService(database: Database): MetricsService {
 
 private fun messageReceiver(
     kafkaReceiver: KafkaReceiver<String, ByteArray>,
+    kafkaPublisher: KafkaPublisher<String, ByteArray>,
     metrics: Metrics
 ): MessageReceiver =
-    MessageReceiver(config().kafka.topics.dialogMessageOut, kafkaReceiver, metrics)
+    MessageReceiver(
+        config().kafka.topics.dialogMessageOut,
+        kafkaReceiver,
+        MessageErrorHandler(
+            metrics,
+            errorMessagePublisher(kafkaPublisher)
+        )
+    )

--- a/src/main/kotlin/no/nav/helsemelding/outbound/config/Config.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/config/Config.kt
@@ -96,7 +96,8 @@ fun Config.withKafka(update: Kafka.() -> Kafka) = copy(kafka = kafka.update())
 data class Topics(
     val dialogMessageIn: String,
     val dialogMessageOut: String,
-    val statusMessage: String
+    val statusMessage: String,
+    val errorMessage: String
 )
 
 data class Server(

--- a/src/main/kotlin/no/nav/helsemelding/outbound/handler/MessageErrorHandler.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/handler/MessageErrorHandler.kt
@@ -49,7 +49,7 @@ class MessageErrorHandler(
         record: MessageRecord
     ): MessageErrorEvent =
         MessageErrorEvent(
-            timestamp = Clock.System.now(),
+            processedAt = Clock.System.now(),
             error = ErrorInfo(
                 category = ErrorCategory.VALIDATION,
                 code = ErrorCode.INVALID_KAFKA_KEY,

--- a/src/main/kotlin/no/nav/helsemelding/outbound/handler/MessageErrorHandler.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/handler/MessageErrorHandler.kt
@@ -1,6 +1,5 @@
 package no.nav.helsemelding.outbound.handler
 
-import io.github.nomisRev.kafka.receiver.ReceiverRecord
 import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.helsemelding.outbound.metrics.ErrorTypeTag
 import no.nav.helsemelding.outbound.metrics.Metrics
@@ -8,6 +7,7 @@ import no.nav.helsemelding.outbound.model.ErrorCategory
 import no.nav.helsemelding.outbound.model.ErrorCode
 import no.nav.helsemelding.outbound.model.ErrorInfo
 import no.nav.helsemelding.outbound.model.MessageErrorEvent
+import no.nav.helsemelding.outbound.model.MessageRecord
 import no.nav.helsemelding.outbound.model.OriginalMessage
 import no.nav.helsemelding.outbound.publisher.ErrorMessagePublisher
 import no.nav.helsemelding.outbound.receiver.RecordKeyValidation
@@ -18,7 +18,7 @@ private val log = KotlinLogging.logger {}
 
 interface MessageHandler {
     suspend fun handleInvalidKafkaKey(
-        record: ReceiverRecord<String, ByteArray>,
+        record: MessageRecord,
         validation: RecordKeyValidation.Invalid
     )
 }
@@ -27,12 +27,13 @@ class MessageErrorHandler(
     private val metrics: Metrics,
     private val errorMessagePublisher: ErrorMessagePublisher
 ) : MessageHandler {
+
     override suspend fun handleInvalidKafkaKey(
-        record: ReceiverRecord<String, ByteArray>,
+        record: MessageRecord,
         validation: RecordKeyValidation.Invalid
     ) {
         log.error {
-            "Invalid Kafka key. Key: ${record.key()}, offset: ${record.offset.offset}. Reason: ${validation.reason}"
+            "Invalid Kafka key. Key: ${record.key}, offset: ${record.offset}. Reason: ${validation.reason}"
         }
 
         metrics.registerOutgoingMessageFailed(ErrorTypeTag.INVALID_KAFKA_KEY)
@@ -45,39 +46,34 @@ class MessageErrorHandler(
 
     private fun toMessageErrorEvent(
         validation: RecordKeyValidation.Invalid,
-        record: ReceiverRecord<String, ByteArray>
-    ): MessageErrorEvent = MessageErrorEvent(
-        Clock.System.now(),
-        ErrorInfo(
-            category = ErrorCategory.VALIDATION,
-            code = ErrorCode.INVALID_KAFKA_KEY,
-            message = validation.reason
-
-        ),
-        OriginalMessage(
-            record.key(),
-            record.value().decodeToString()
+        record: MessageRecord
+    ): MessageErrorEvent =
+        MessageErrorEvent(
+            timestamp = Clock.System.now(),
+            error = ErrorInfo(
+                category = ErrorCategory.VALIDATION,
+                code = ErrorCode.INVALID_KAFKA_KEY,
+                message = validation.reason
+            ),
+            originalMessage = OriginalMessage(
+                key = record.key,
+                payload = record.payload.decodeToString()
+            )
         )
-    )
 }
 
-class FakeMessageErrorHandler : MessageHandler {
-    val handledInvalidKafkaKeys = mutableListOf<HandledInvalidKafkaKey>()
+class FakeMessageHandler : MessageHandler {
+    val invalidKafkaKeys = mutableListOf<InvalidKafkaKey>()
 
     override suspend fun handleInvalidKafkaKey(
-        record: ReceiverRecord<String, ByteArray>,
+        record: MessageRecord,
         validation: RecordKeyValidation.Invalid
     ) {
-        handledInvalidKafkaKeys += HandledInvalidKafkaKey(
-            key = record.key(),
-            payload = record.value(),
-            reason = validation.reason
-        )
+        invalidKafkaKeys += InvalidKafkaKey(record, validation)
     }
 
-    data class HandledInvalidKafkaKey(
-        val key: String?,
-        val payload: ByteArray,
-        val reason: String
+    data class InvalidKafkaKey(
+        val record: MessageRecord,
+        val validation: RecordKeyValidation.Invalid
     )
 }

--- a/src/main/kotlin/no/nav/helsemelding/outbound/handler/MessageErrorHandler.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/handler/MessageErrorHandler.kt
@@ -1,0 +1,83 @@
+package no.nav.helsemelding.outbound.handler
+
+import io.github.nomisRev.kafka.receiver.ReceiverRecord
+import io.github.oshai.kotlinlogging.KotlinLogging
+import no.nav.helsemelding.outbound.metrics.ErrorTypeTag
+import no.nav.helsemelding.outbound.metrics.Metrics
+import no.nav.helsemelding.outbound.model.ErrorCategory
+import no.nav.helsemelding.outbound.model.ErrorCode
+import no.nav.helsemelding.outbound.model.ErrorInfo
+import no.nav.helsemelding.outbound.model.MessageErrorEvent
+import no.nav.helsemelding.outbound.model.OriginalMessage
+import no.nav.helsemelding.outbound.publisher.ErrorMessagePublisher
+import no.nav.helsemelding.outbound.receiver.RecordKeyValidation
+import kotlin.time.Clock
+import kotlin.uuid.Uuid
+
+private val log = KotlinLogging.logger {}
+
+interface MessageHandler {
+    suspend fun handleInvalidKafkaKey(
+        record: ReceiverRecord<String, ByteArray>,
+        validation: RecordKeyValidation.Invalid
+    )
+}
+
+class MessageErrorHandler(
+    private val metrics: Metrics,
+    private val errorMessagePublisher: ErrorMessagePublisher
+) : MessageHandler {
+    override suspend fun handleInvalidKafkaKey(
+        record: ReceiverRecord<String, ByteArray>,
+        validation: RecordKeyValidation.Invalid
+    ) {
+        log.error {
+            "Invalid Kafka key. Key: ${record.key()}, offset: ${record.offset.offset}. Reason: ${validation.reason}"
+        }
+
+        metrics.registerOutgoingMessageFailed(ErrorTypeTag.INVALID_KAFKA_KEY)
+
+        errorMessagePublisher.publish(
+            Uuid.random(),
+            toMessageErrorEvent(validation, record)
+        )
+    }
+
+    private fun toMessageErrorEvent(
+        validation: RecordKeyValidation.Invalid,
+        record: ReceiverRecord<String, ByteArray>
+    ): MessageErrorEvent = MessageErrorEvent(
+        Clock.System.now(),
+        ErrorInfo(
+            category = ErrorCategory.VALIDATION,
+            code = ErrorCode.INVALID_KAFKA_KEY,
+            message = validation.reason
+
+        ),
+        OriginalMessage(
+            record.key(),
+            record.value().decodeToString()
+        )
+    )
+}
+
+class FakeMessageErrorHandler : MessageHandler {
+    val handledInvalidKafkaKeys = mutableListOf<HandledInvalidKafkaKey>()
+
+    override suspend fun handleInvalidKafkaKey(
+        record: ReceiverRecord<String, ByteArray>,
+        validation: RecordKeyValidation.Invalid
+    ) {
+        handledInvalidKafkaKeys += HandledInvalidKafkaKey(
+            key = record.key(),
+            payload = record.value(),
+            reason = validation.reason
+        )
+    }
+
+    data class HandledInvalidKafkaKey(
+        val key: String?,
+        val payload: ByteArray,
+        val reason: String
+    )
+}

--- a/src/main/kotlin/no/nav/helsemelding/outbound/model/ErrorCategory.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/model/ErrorCategory.kt
@@ -1,0 +1,9 @@
+package no.nav.helsemelding.outbound.model
+
+enum class ErrorCategory {
+    VALIDATION,
+    DESERIALIZATION,
+    BUSINESS_RULE,
+    DOWNSTREAM,
+    UNKNOWN
+}

--- a/src/main/kotlin/no/nav/helsemelding/outbound/model/ErrorCategory.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/model/ErrorCategory.kt
@@ -1,9 +1,5 @@
 package no.nav.helsemelding.outbound.model
 
 enum class ErrorCategory {
-    VALIDATION,
-    DESERIALIZATION,
-    BUSINESS_RULE,
-    DOWNSTREAM,
-    UNKNOWN
+    VALIDATION
 }

--- a/src/main/kotlin/no/nav/helsemelding/outbound/model/ErrorCode.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/model/ErrorCode.kt
@@ -1,0 +1,8 @@
+package no.nav.helsemelding.outbound.model
+
+enum class ErrorCode {
+    INVALID_KAFKA_KEY,
+    INVALID_XML,
+    MISSING_REQUIRED_FIELD,
+    UNEXPECTED_ERROR
+}

--- a/src/main/kotlin/no/nav/helsemelding/outbound/model/ErrorCode.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/model/ErrorCode.kt
@@ -1,8 +1,5 @@
 package no.nav.helsemelding.outbound.model
 
 enum class ErrorCode {
-    INVALID_KAFKA_KEY,
-    INVALID_XML,
-    MISSING_REQUIRED_FIELD,
-    UNEXPECTED_ERROR
+    INVALID_KAFKA_KEY
 }

--- a/src/main/kotlin/no/nav/helsemelding/outbound/model/ErrorInfo.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/model/ErrorInfo.kt
@@ -1,0 +1,10 @@
+package no.nav.helsemelding.outbound.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ErrorInfo(
+    val category: ErrorCategory,
+    val code: ErrorCode,
+    val message: String
+)

--- a/src/main/kotlin/no/nav/helsemelding/outbound/model/MessageErrorEvent.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/model/MessageErrorEvent.kt
@@ -1,0 +1,11 @@
+package no.nav.helsemelding.outbound.model
+
+import kotlinx.serialization.Serializable
+import kotlin.time.Instant
+
+@Serializable
+data class MessageErrorEvent(
+    val timestamp: Instant,
+    val error: ErrorInfo,
+    val originalMessage: OriginalMessage
+)

--- a/src/main/kotlin/no/nav/helsemelding/outbound/model/MessageErrorEvent.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/model/MessageErrorEvent.kt
@@ -5,7 +5,7 @@ import kotlin.time.Instant
 
 @Serializable
 data class MessageErrorEvent(
-    val timestamp: Instant,
+    val processedAt: Instant,
     val error: ErrorInfo,
     val originalMessage: OriginalMessage
 )

--- a/src/main/kotlin/no/nav/helsemelding/outbound/model/MessageRecord.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/model/MessageRecord.kt
@@ -3,5 +3,6 @@ package no.nav.helsemelding.outbound.model
 data class MessageRecord(
     val key: String?,
     val payload: ByteArray,
-    val offset: Long
+    val offset: Long,
+    val occuredAt: Long
 )

--- a/src/main/kotlin/no/nav/helsemelding/outbound/model/MessageRecord.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/model/MessageRecord.kt
@@ -4,5 +4,5 @@ data class MessageRecord(
     val key: String?,
     val payload: ByteArray,
     val offset: Long,
-    val occuredAt: Long
+    val occurredAt: Long
 )

--- a/src/main/kotlin/no/nav/helsemelding/outbound/model/MessageRecord.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/model/MessageRecord.kt
@@ -1,0 +1,7 @@
+package no.nav.helsemelding.outbound.model
+
+data class MessageRecord(
+    val key: String?,
+    val payload: ByteArray,
+    val offset: Long
+)

--- a/src/main/kotlin/no/nav/helsemelding/outbound/model/MessageStatusEvent.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/model/MessageStatusEvent.kt
@@ -1,7 +1,6 @@
 package no.nav.helsemelding.outbound.model
 
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
 import kotlin.time.Instant
 import kotlin.uuid.Uuid
 
@@ -13,5 +12,3 @@ data class MessageStatusEvent(
     val apprec: AppRecPayload? = null,
     val error: ErrorPayload? = null
 )
-
-fun MessageStatusEvent.toJson(): String = Json.encodeToString(MessageStatusEvent.serializer(), this)

--- a/src/main/kotlin/no/nav/helsemelding/outbound/model/OriginalMessage.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/model/OriginalMessage.kt
@@ -1,0 +1,9 @@
+package no.nav.helsemelding.outbound.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class OriginalMessage(
+    val key: String?,
+    val payload: String?
+)

--- a/src/main/kotlin/no/nav/helsemelding/outbound/publisher/MessagePublisher.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/publisher/MessagePublisher.kt
@@ -68,7 +68,7 @@ private class GenericMessagePublisher<T>(
 
 class FakeStatusMessagePublisher(
     private val topic: String = config().kafka.topics.statusMessage
-) : MessagePublisher<MessageStatusEvent> {
+) : StatusMessagePublisher {
 
     val published = mutableListOf<MessageStatusEvent>()
     var failNext = false
@@ -100,5 +100,26 @@ class FakeStatusMessagePublisher(
         )
 
         return md.right()
+    }
+}
+
+class FakeErrorMessagePublisher : ErrorMessagePublisher {
+    val published = mutableListOf<Pair<Uuid, MessageErrorEvent>>()
+
+    override suspend fun publish(
+        referenceId: Uuid,
+        message: MessageErrorEvent
+    ): Either<PublishError, RecordMetadata> {
+        published += referenceId to message
+
+        return RecordMetadata(
+            TopicPartition("helsemelding.dialog.out.error", 0),
+            0L,
+            0,
+            System.currentTimeMillis(),
+            referenceId.toByteArray().size,
+            message.toJson().encodeToByteArray().size
+        )
+            .right()
     }
 }

--- a/src/main/kotlin/no/nav/helsemelding/outbound/publisher/MessagePublisher.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/publisher/MessagePublisher.kt
@@ -4,51 +4,62 @@ import arrow.core.Either
 import arrow.core.left
 import arrow.core.right
 import io.github.nomisRev.kafka.publisher.KafkaPublisher
-import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.helsemelding.outbound.PublishError
 import no.nav.helsemelding.outbound.config
+import no.nav.helsemelding.outbound.model.MessageErrorEvent
+import no.nav.helsemelding.outbound.model.MessageStatusEvent
 import no.nav.helsemelding.outbound.util.toEither
+import no.nav.helsemelding.outbound.util.toJson
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.clients.producer.RecordMetadata
 import org.apache.kafka.common.TopicPartition
 import kotlin.uuid.Uuid
 
-private val log = KotlinLogging.logger {}
+typealias StatusMessagePublisher = MessagePublisher<MessageStatusEvent>
+typealias ErrorMessagePublisher = MessagePublisher<MessageErrorEvent>
 
-typealias DialogMessagePublisher = MessagePublisher
-typealias StatusMessagePublisher = MessagePublisher
-
-interface MessagePublisher {
-    suspend fun publish(referenceId: Uuid, message: String): Either<PublishError, RecordMetadata>
+interface MessagePublisher<T> {
+    suspend fun publish(referenceId: Uuid, message: T): Either<PublishError, RecordMetadata>
 }
-
-fun dialogMessagePublisher(
-    kafkaPublisher: KafkaPublisher<String, ByteArray>
-): DialogMessagePublisher =
-    GenericMessagePublisher(
-        kafkaPublisher = kafkaPublisher,
-        topic = config().kafka.topics.dialogMessageIn
-    )
 
 fun statusMessagePublisher(
     kafkaPublisher: KafkaPublisher<String, ByteArray>
 ): StatusMessagePublisher =
-    GenericMessagePublisher(
+    genericMessagePublisher(
         kafkaPublisher = kafkaPublisher,
         topic = config().kafka.topics.statusMessage
     )
 
-private class GenericMessagePublisher(
+fun errorMessagePublisher(
+    kafkaPublisher: KafkaPublisher<String, ByteArray>
+): ErrorMessagePublisher =
+    genericMessagePublisher(
+        kafkaPublisher = kafkaPublisher,
+        topic = config().kafka.topics.errorMessage
+    )
+
+private inline fun <reified T> genericMessagePublisher(
+    kafkaPublisher: KafkaPublisher<String, ByteArray>,
+    topic: String
+): MessagePublisher<T> =
+    GenericMessagePublisher(
+        kafkaPublisher = kafkaPublisher,
+        topic = topic,
+        serialize = { message -> message.toJson().toByteArray() }
+    )
+
+private class GenericMessagePublisher<T>(
     private val kafkaPublisher: KafkaPublisher<String, ByteArray>,
-    private val topic: String
-) : MessagePublisher {
-    override suspend fun publish(referenceId: Uuid, message: String): Either<PublishError, RecordMetadata> =
+    private val topic: String,
+    private val serialize: (T) -> ByteArray
+) : MessagePublisher<T> {
+    override suspend fun publish(referenceId: Uuid, message: T): Either<PublishError, RecordMetadata> =
         kafkaPublisher.publishScope {
             publishCatching(
                 ProducerRecord(
                     topic,
                     referenceId.toString(),
-                    message.toByteArray()
+                    serialize(message)
                 )
             )
         }
@@ -57,24 +68,27 @@ private class GenericMessagePublisher(
 
 class FakeStatusMessagePublisher(
     private val topic: String = config().kafka.topics.statusMessage
-) : MessagePublisher {
+) : MessagePublisher<MessageStatusEvent> {
 
-    val published = mutableListOf<ByteArray>()
+    val published = mutableListOf<MessageStatusEvent>()
     var failNext = false
 
-    override suspend fun publish(referenceId: Uuid, message: String): Either<PublishError, RecordMetadata> {
+    override suspend fun publish(
+        referenceId: Uuid,
+        message: MessageStatusEvent
+    ): Either<PublishError, RecordMetadata> {
         if (failNext) {
             failNext = false
             return PublishError.Failure(
                 messageId = referenceId,
                 topic = topic,
                 cause = RuntimeException("Publish failure")
-            )
-                .left()
+            ).left()
         }
 
-        val bytes = message.toByteArray()
-        published += bytes
+        published += message
+
+        val bytes = message.toJson().toByteArray()
 
         val md = RecordMetadata(
             TopicPartition(topic, 0),

--- a/src/main/kotlin/no/nav/helsemelding/outbound/publisher/MessagePublisher.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/publisher/MessagePublisher.kt
@@ -69,7 +69,6 @@ private class GenericMessagePublisher<T>(
 class FakeStatusMessagePublisher(
     private val topic: String = config().kafka.topics.statusMessage
 ) : StatusMessagePublisher {
-
     val published = mutableListOf<MessageStatusEvent>()
     var failNext = false
 
@@ -103,7 +102,9 @@ class FakeStatusMessagePublisher(
     }
 }
 
-class FakeErrorMessagePublisher : ErrorMessagePublisher {
+class FakeErrorMessagePublisher(
+    private val topic: String = config().kafka.topics.errorMessage
+) : ErrorMessagePublisher {
     val published = mutableListOf<Pair<Uuid, MessageErrorEvent>>()
 
     override suspend fun publish(
@@ -113,7 +114,7 @@ class FakeErrorMessagePublisher : ErrorMessagePublisher {
         published += referenceId to message
 
         return RecordMetadata(
-            TopicPartition("helsemelding.dialog.out.error", 0),
+            TopicPartition(topic, 0),
             0L,
             0,
             System.currentTimeMillis(),

--- a/src/main/kotlin/no/nav/helsemelding/outbound/receiver/MessageReceiver.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/receiver/MessageReceiver.kt
@@ -6,21 +6,27 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.mapNotNull
 import no.nav.helsemelding.outbound.handler.MessageHandler
 import no.nav.helsemelding.outbound.model.DialogMessage
+import no.nav.helsemelding.outbound.model.MessageRecord
 import kotlin.uuid.Uuid
 
 class MessageReceiver(
     private val dialogMessageOutTopic: String,
     private val kafkaReceiver: KafkaReceiver<String, ByteArray>,
-    private val errorHandler: MessageHandler
+    private val messageHandler: MessageHandler
 ) {
     fun receiveMessages(): Flow<DialogMessage> =
         kafkaReceiver
             .receive(dialogMessageOutTopic)
             .mapNotNull { record ->
                 when (val validation = validateRecordKey(record)) {
-                    RecordKeyValidation.Valid -> toMessage(record)
+                    RecordKeyValidation.Valid ->
+                        toMessage(record)
+
                     is RecordKeyValidation.Invalid -> {
-                        errorHandler.handleInvalidKafkaKey(record, validation)
+                        messageHandler.handleInvalidKafkaKey(
+                            record = record.toMessageRecord(),
+                            validation = validation
+                        )
                         null
                     }
                 }
@@ -30,6 +36,13 @@ class MessageReceiver(
         DialogMessage(
             Uuid.parse(record.key()),
             record.value()
+        )
+
+    private fun ReceiverRecord<String, ByteArray>.toMessageRecord(): MessageRecord =
+        MessageRecord(
+            key = key(),
+            payload = value(),
+            offset = offset.offset
         )
 }
 

--- a/src/main/kotlin/no/nav/helsemelding/outbound/receiver/MessageReceiver.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/receiver/MessageReceiver.kt
@@ -43,7 +43,7 @@ class MessageReceiver(
             key = key(),
             payload = value(),
             offset = offset.offset,
-            occuredAt = timestamp()
+            occurredAt = timestamp()
         )
 }
 

--- a/src/main/kotlin/no/nav/helsemelding/outbound/receiver/MessageReceiver.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/receiver/MessageReceiver.kt
@@ -42,7 +42,8 @@ class MessageReceiver(
         MessageRecord(
             key = key(),
             payload = value(),
-            offset = offset.offset
+            offset = offset.offset,
+            occuredAt = timestamp()
         )
 }
 

--- a/src/main/kotlin/no/nav/helsemelding/outbound/receiver/MessageReceiver.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/receiver/MessageReceiver.kt
@@ -2,69 +2,54 @@ package no.nav.helsemelding.outbound.receiver
 
 import io.github.nomisRev.kafka.receiver.KafkaReceiver
 import io.github.nomisRev.kafka.receiver.ReceiverRecord
-import io.github.nomisRev.kafka.receiver.ReceiverSettings
-import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
-import no.nav.helsemelding.outbound.metrics.ErrorTypeTag
-import no.nav.helsemelding.outbound.metrics.Metrics
+import kotlinx.coroutines.flow.mapNotNull
+import no.nav.helsemelding.outbound.handler.MessageHandler
 import no.nav.helsemelding.outbound.model.DialogMessage
-import org.apache.kafka.common.serialization.ByteArrayDeserializer
-import org.apache.kafka.common.serialization.StringDeserializer
 import kotlin.uuid.Uuid
-
-private val log = KotlinLogging.logger {}
 
 class MessageReceiver(
     private val dialogMessageOutTopic: String,
     private val kafkaReceiver: KafkaReceiver<String, ByteArray>,
-    private val metrics: Metrics
+    private val errorHandler: MessageHandler
 ) {
-    fun receiveMessages(): Flow<DialogMessage> = kafkaReceiver
-        .receive(dialogMessageOutTopic)
-        .filter { record -> isValidRecordKey(record, metrics) }
-        .onEach { metrics.registerOutgoingMessageReceived() }
-        .map(::toMessage)
+    fun receiveMessages(): Flow<DialogMessage> =
+        kafkaReceiver
+            .receive(dialogMessageOutTopic)
+            .mapNotNull { record ->
+                when (val validation = validateRecordKey(record)) {
+                    RecordKeyValidation.Valid -> toMessage(record)
+                    is RecordKeyValidation.Invalid -> {
+                        errorHandler.handleInvalidKafkaKey(record, validation)
+                        null
+                    }
+                }
+            }
 
-    private suspend fun toMessage(record: ReceiverRecord<String, ByteArray>): DialogMessage {
-        return DialogMessage(
+    private fun toMessage(record: ReceiverRecord<String, ByteArray>): DialogMessage =
+        DialogMessage(
             Uuid.parse(record.key()),
             record.value()
         )
-    }
 }
 
-internal fun isValidRecordKey(
-    record: ReceiverRecord<String, ByteArray>,
-    metrics: Metrics
-): Boolean {
-    val key = record.key()
-    if (key == null) {
-        log.error { "Receiver record key is null. Key should be a valid uuid. Offset: ${record.offset.offset}" }
-        metrics.registerOutgoingMessageFailed(ErrorTypeTag.INVALID_KAFKA_KEY)
-        return false
-    }
+sealed interface RecordKeyValidation {
+    data object Valid : RecordKeyValidation
 
-    return if (Uuid.parseOrNull(key) != null) {
-        true
-    } else {
-        log.error { "Receiver record key: $key is invalid and therefore ignored." }
-        metrics.registerOutgoingMessageFailed(ErrorTypeTag.INVALID_KAFKA_KEY)
-        false
-    }
+    data class Invalid(
+        val reason: String
+    ) : RecordKeyValidation
 }
 
-fun fakeMessageReceiver(metrics: Metrics): MessageReceiver = MessageReceiver(
-    "fake.dialog.topic",
-    KafkaReceiver(
-        ReceiverSettings(
-            bootstrapServers = "",
-            keyDeserializer = StringDeserializer(),
-            valueDeserializer = ByteArrayDeserializer(),
-            groupId = ""
-        )
-    ),
-    metrics
-)
+internal fun validateRecordKey(
+    record: ReceiverRecord<String, ByteArray>
+): RecordKeyValidation =
+    when (val key = record.key()) {
+        null -> RecordKeyValidation.Invalid("Kafka record key is null")
+        else ->
+            if (Uuid.parseOrNull(key) == null) {
+                RecordKeyValidation.Invalid("Kafka record key is not a valid UUID")
+            } else {
+                RecordKeyValidation.Valid
+            }
+    }

--- a/src/main/kotlin/no/nav/helsemelding/outbound/service/PollerService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/service/PollerService.kt
@@ -41,7 +41,6 @@ import no.nav.helsemelding.outbound.model.formatInvalidState
 import no.nav.helsemelding.outbound.model.formatTransition
 import no.nav.helsemelding.outbound.model.formatUnchanged
 import no.nav.helsemelding.outbound.model.logPrefix
-import no.nav.helsemelding.outbound.model.toJson
 import no.nav.helsemelding.outbound.publisher.StatusMessagePublisher
 import no.nav.helsemelding.outbound.util.translate
 import no.nav.helsemelding.outbound.util.withSpan
@@ -221,7 +220,7 @@ class PollerService(
     ): Either<PublishError, RecordMetadata> =
         statusMessagePublisher.publish(
             message.id,
-            statusMessageEvent(message, decision, apprecInfo).toJson()
+            statusMessageEvent(message, decision, apprecInfo)
         ).withLogging(message.id)
 
     private fun statusMessageEvent(

--- a/src/main/kotlin/no/nav/helsemelding/outbound/util/Json.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/util/Json.kt
@@ -1,0 +1,5 @@
+package no.nav.helsemelding.outbound.util
+
+import kotlinx.serialization.json.Json
+
+inline fun <reified T> T.toJson(): String = Json.encodeToString(this)

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -12,6 +12,7 @@ kafka {
     dialogMessageIn = "helsemelding.dialog.in.xml"
     dialogMessageOut = "helsemelding.dialog.out.xml"
     statusMessage = "helsemelding.dialog.status.json"
+    errorMessage = "helsemelding.dialog.out.error"
   }
 }
 

--- a/src/test/kotlin/no/nav/helsemelding/outbound/handler/MessageErrorHandlerSpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/outbound/handler/MessageErrorHandlerSpec.kt
@@ -1,0 +1,84 @@
+package no.nav.helsemelding.outbound.handler
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import no.nav.helsemelding.outbound.metrics.FakeMetrics
+import no.nav.helsemelding.outbound.model.ErrorCategory
+import no.nav.helsemelding.outbound.model.ErrorCode
+import no.nav.helsemelding.outbound.model.ErrorInfo
+import no.nav.helsemelding.outbound.model.MessageRecord
+import no.nav.helsemelding.outbound.model.OriginalMessage
+import no.nav.helsemelding.outbound.publisher.FakeErrorMessagePublisher
+import no.nav.helsemelding.outbound.receiver.RecordKeyValidation
+
+class MessageErrorHandlerSpec : StringSpec(
+    {
+        lateinit var metrics: FakeMetrics
+        lateinit var publisher: FakeErrorMessagePublisher
+        lateinit var handler: MessageErrorHandler
+
+        beforeTest {
+            metrics = FakeMetrics()
+            publisher = FakeErrorMessagePublisher()
+            handler = MessageErrorHandler(
+                metrics = metrics,
+                errorMessagePublisher = publisher
+            )
+        }
+
+        "should publish message error event for invalid kafka key" {
+            val record = MessageRecord(
+                key = "not-a-uuid",
+                payload = """{"foo":"bar"}""".encodeToByteArray(),
+                offset = 42L
+            )
+
+            val validation = RecordKeyValidation.Invalid(
+                reason = "Kafka record key is not a valid UUID"
+            )
+
+            handler.handleInvalidKafkaKey(record, validation)
+
+            publisher.published shouldHaveSize 1
+
+            val (_, event) = publisher.published.single()
+
+            event.error shouldBe ErrorInfo(
+                category = ErrorCategory.VALIDATION,
+                code = ErrorCode.INVALID_KAFKA_KEY,
+                message = "Kafka record key is not a valid UUID"
+            )
+
+            event.originalMessage shouldBe OriginalMessage(
+                key = "not-a-uuid",
+                payload = """{"foo":"bar"}"""
+            )
+        }
+
+        "should include null key in original message when kafka key is missing" {
+            val record = MessageRecord(
+                key = null,
+                payload = """{"foo":"bar"}""".encodeToByteArray(),
+                offset = 42L
+            )
+
+            val validation = RecordKeyValidation.Invalid(
+                reason = "Kafka record key is null"
+            )
+
+            handler.handleInvalidKafkaKey(record, validation)
+
+            publisher.published shouldHaveSize 1
+
+            val (_, event) = publisher.published.single()
+
+            event.originalMessage shouldBe OriginalMessage(
+                key = null,
+                payload = """{"foo":"bar"}"""
+            )
+
+            event.error.message shouldBe "Kafka record key is null"
+        }
+    }
+)

--- a/src/test/kotlin/no/nav/helsemelding/outbound/handler/MessageErrorHandlerSpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/outbound/handler/MessageErrorHandlerSpec.kt
@@ -33,7 +33,7 @@ class MessageErrorHandlerSpec : StringSpec(
                 key = "not-a-uuid",
                 payload = """{"foo":"bar"}""".encodeToByteArray(),
                 offset = 42L,
-                occuredAt = Clock.System.now().epochSeconds
+                occurredAt = Clock.System.now().epochSeconds
             )
 
             val validation = RecordKeyValidation.Invalid(
@@ -63,7 +63,7 @@ class MessageErrorHandlerSpec : StringSpec(
                 key = null,
                 payload = """{"foo":"bar"}""".encodeToByteArray(),
                 offset = 42L,
-                occuredAt = Clock.System.now().epochSeconds
+                occurredAt = Clock.System.now().epochSeconds
             )
 
             val validation = RecordKeyValidation.Invalid(

--- a/src/test/kotlin/no/nav/helsemelding/outbound/handler/MessageErrorHandlerSpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/outbound/handler/MessageErrorHandlerSpec.kt
@@ -11,6 +11,7 @@ import no.nav.helsemelding.outbound.model.MessageRecord
 import no.nav.helsemelding.outbound.model.OriginalMessage
 import no.nav.helsemelding.outbound.publisher.FakeErrorMessagePublisher
 import no.nav.helsemelding.outbound.receiver.RecordKeyValidation
+import kotlin.time.Clock
 
 class MessageErrorHandlerSpec : StringSpec(
     {
@@ -31,7 +32,8 @@ class MessageErrorHandlerSpec : StringSpec(
             val record = MessageRecord(
                 key = "not-a-uuid",
                 payload = """{"foo":"bar"}""".encodeToByteArray(),
-                offset = 42L
+                offset = 42L,
+                occuredAt = Clock.System.now().epochSeconds
             )
 
             val validation = RecordKeyValidation.Invalid(
@@ -60,7 +62,8 @@ class MessageErrorHandlerSpec : StringSpec(
             val record = MessageRecord(
                 key = null,
                 payload = """{"foo":"bar"}""".encodeToByteArray(),
-                offset = 42L
+                offset = 42L,
+                occuredAt = Clock.System.now().epochSeconds
             )
 
             val validation = RecordKeyValidation.Invalid(

--- a/src/test/kotlin/no/nav/helsemelding/outbound/poller/PollerServiceSpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/outbound/poller/PollerServiceSpec.kt
@@ -4,7 +4,6 @@ import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import kotlinx.serialization.json.Json
 import no.nav.helsemelding.ediadapter.client.EdiAdapterClient
 import no.nav.helsemelding.ediadapter.model.AppRecStatus.OK
 import no.nav.helsemelding.ediadapter.model.ApprecInfo
@@ -21,11 +20,10 @@ import no.nav.helsemelding.outbound.model.ExternalDeliveryState.ACKNOWLEDGED
 import no.nav.helsemelding.outbound.model.MessageStatus
 import no.nav.helsemelding.outbound.model.MessageStatus.PENDING_APPREC
 import no.nav.helsemelding.outbound.model.MessageStatus.PENDING_TRANSPORT
-import no.nav.helsemelding.outbound.model.MessageStatusEvent
 import no.nav.helsemelding.outbound.model.MessageType.DIALOG
 import no.nav.helsemelding.outbound.model.UpdateState
 import no.nav.helsemelding.outbound.publisher.FakeStatusMessagePublisher
-import no.nav.helsemelding.outbound.publisher.MessagePublisher
+import no.nav.helsemelding.outbound.publisher.StatusMessagePublisher
 import no.nav.helsemelding.outbound.service.FakeTransactionalMessageStateService
 import no.nav.helsemelding.outbound.service.MessageStateService
 import no.nav.helsemelding.outbound.service.PollerService
@@ -166,13 +164,13 @@ class PollerServiceSpec : StringSpec(
                 )
             ).shouldBeRight()
 
-            ediAdapterClient.givenStatus(externalRefId, DeliveryState.UNCONFIRMED, null)
+            ediAdapterClient.givenStatus(externalRefId, UNCONFIRMED, null)
 
             pollerService.pollAndProcessMessage(snapshot.messageState)
 
             statusMessagePublisher.published.size shouldBe 1
 
-            val event = decodeStatusEvent(statusMessagePublisher.published.single())
+            val event = statusMessagePublisher.published.single()
             event.messageId shouldBe id
             event.status shouldBe PENDING_TRANSPORT
             event.apprec shouldBe null
@@ -201,7 +199,7 @@ class PollerServiceSpec : StringSpec(
 
             statusMessagePublisher.published.size shouldBe 1
 
-            val event = decodeStatusEvent(statusMessagePublisher.published.single())
+            val event = statusMessagePublisher.published.single()
             event.messageId shouldBe id
             event.status shouldBe PENDING_APPREC
             event.apprec shouldBe null
@@ -243,7 +241,7 @@ class PollerServiceSpec : StringSpec(
 
             statusMessagePublisher.published.size shouldBe 1
 
-            val event = decodeStatusEvent(statusMessagePublisher.published.single())
+            val event = statusMessagePublisher.published.single()
             event.messageId shouldBe id
             event.status shouldBe MessageStatus.COMPLETED
             event.error shouldBe null
@@ -275,7 +273,7 @@ class PollerServiceSpec : StringSpec(
 
             statusMessagePublisher.published.size shouldBe 1
 
-            val event = decodeStatusEvent(statusMessagePublisher.published.single())
+            val event = statusMessagePublisher.published.single()
             event.messageId shouldBe id
             event.status shouldBe MessageStatus.REJECTED_TRANSPORT
             event.apprec shouldBe null
@@ -318,7 +316,7 @@ class PollerServiceSpec : StringSpec(
 
             statusMessagePublisher.published.size shouldBe 1
 
-            val event = decodeStatusEvent(statusMessagePublisher.published.single())
+            val event = statusMessagePublisher.published.single()
             event.messageId shouldBe id
             event.status shouldBe MessageStatus.REJECTED_APPREC
             event.error shouldBe null
@@ -349,7 +347,7 @@ class PollerServiceSpec : StringSpec(
 
             statusMessagePublisher.published.size shouldBe 1
 
-            val event = decodeStatusEvent(statusMessagePublisher.published.single())
+            val event = statusMessagePublisher.published.single()
             event.messageId shouldBe id
             event.status shouldBe MessageStatus.INVALID
             event.apprec shouldBe null
@@ -386,7 +384,7 @@ private fun fixture(): Fixture {
 private fun pollerService(
     ediAdapterClient: EdiAdapterClient,
     messageStateService: MessageStateService,
-    messagePublisher: MessagePublisher
+    messagePublisher: StatusMessagePublisher
 ): PollerService = PollerService(
     ediAdapterClient,
     messageStateService,
@@ -401,5 +399,3 @@ private fun stateEvaluatorService(): StateEvaluatorService = StateEvaluatorServi
         AppRecTransitionEvaluator()
     )
 )
-
-private fun decodeStatusEvent(bytes: ByteArray): MessageStatusEvent = Json.decodeFromString(String(bytes))

--- a/src/test/kotlin/no/nav/helsemelding/outbound/receiver/MessageReceiverSpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/outbound/receiver/MessageReceiverSpec.kt
@@ -14,8 +14,8 @@ import no.nav.helsemelding.outbound.config
 import no.nav.helsemelding.outbound.config.Config
 import no.nav.helsemelding.outbound.config.Kafka.SecurityProtocol
 import no.nav.helsemelding.outbound.config.withKafka
+import no.nav.helsemelding.outbound.handler.FakeMessageErrorHandler
 import no.nav.helsemelding.outbound.kafkaReceiver
-import no.nav.helsemelding.outbound.metrics.FakeMetrics
 import org.apache.kafka.clients.producer.ProducerRecord
 import kotlin.time.Duration.Companion.seconds
 import kotlin.uuid.Uuid
@@ -54,7 +54,7 @@ class MessageReceiverSpec : KafkaSpec(
                     val receiver = MessageReceiver(
                         topic,
                         kafkaReceiver(config.kafka, AutoOffsetReset.Earliest),
-                        FakeMetrics()
+                        FakeMessageErrorHandler()
                     )
                     val messages = receiver.receiveMessages()
 
@@ -85,7 +85,7 @@ class MessageReceiverSpec : KafkaSpec(
                     val receiver = MessageReceiver(
                         topic,
                         kafkaReceiver(config.kafka, AutoOffsetReset.Earliest),
-                        FakeMetrics()
+                        FakeMessageErrorHandler()
                     )
                     val messages = receiver.receiveMessages()
 
@@ -118,7 +118,7 @@ class MessageReceiverSpec : KafkaSpec(
                     val receiver = MessageReceiver(
                         topic,
                         kafkaReceiver(config.kafka, AutoOffsetReset.Earliest),
-                        FakeMetrics()
+                        FakeMessageErrorHandler()
                     )
                     val messages = receiver.receiveMessages()
 

--- a/src/test/kotlin/no/nav/helsemelding/outbound/receiver/MessageReceiverSpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/outbound/receiver/MessageReceiverSpec.kt
@@ -14,7 +14,7 @@ import no.nav.helsemelding.outbound.config
 import no.nav.helsemelding.outbound.config.Config
 import no.nav.helsemelding.outbound.config.Kafka.SecurityProtocol
 import no.nav.helsemelding.outbound.config.withKafka
-import no.nav.helsemelding.outbound.handler.FakeMessageErrorHandler
+import no.nav.helsemelding.outbound.handler.FakeMessageHandler
 import no.nav.helsemelding.outbound.kafkaReceiver
 import org.apache.kafka.clients.producer.ProducerRecord
 import kotlin.time.Duration.Companion.seconds
@@ -54,7 +54,7 @@ class MessageReceiverSpec : KafkaSpec(
                     val receiver = MessageReceiver(
                         topic,
                         kafkaReceiver(config.kafka, AutoOffsetReset.Earliest),
-                        FakeMessageErrorHandler()
+                        FakeMessageHandler()
                     )
                     val messages = receiver.receiveMessages()
 
@@ -85,7 +85,7 @@ class MessageReceiverSpec : KafkaSpec(
                     val receiver = MessageReceiver(
                         topic,
                         kafkaReceiver(config.kafka, AutoOffsetReset.Earliest),
-                        FakeMessageErrorHandler()
+                        FakeMessageHandler()
                     )
                     val messages = receiver.receiveMessages()
 
@@ -118,7 +118,7 @@ class MessageReceiverSpec : KafkaSpec(
                     val receiver = MessageReceiver(
                         topic,
                         kafkaReceiver(config.kafka, AutoOffsetReset.Earliest),
-                        FakeMessageErrorHandler()
+                        FakeMessageHandler()
                     )
                     val messages = receiver.receiveMessages()
 


### PR DESCRIPTION
In the long run just logging errors are not good enough if we want to build a self contained service platform. Users of the system need to be provided with enough information so they can solve issues they are responsible for handling.

An error topic on Kafka has been created for outbound messages. The error message contains some metadata and the actual payload that was sent. 

The error structure represented in json form:

```
{
  "timestamp": "2026-02-02T12:00:00Z",
  "error": {
    "category": "VALIDATION",
    "code": "INVALID_KAFKA_KEY",
    "message": "Kafka record key is not a valid UUID"
  },
  "originalMessage": {
    "key": "not-a-uuid",
    "payload": "{\"someField\":\"someValue\"}"
  }
}
```

~TODO: Test coverage~

REF: [#49](https://github.com/navikt/helsemelding-outbound-message-service/issues/49#issue-3905367560)