### PR TITLE
Write instant to error json instead of millis

### DIFF
--- a/src/main/kotlin/no/nav/helsemelding/outbound/model/MessageRecord.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/model/MessageRecord.kt
@@ -1,8 +1,10 @@
 package no.nav.helsemelding.outbound.model
 
+import kotlin.time.Instant
+
 data class MessageRecord(
     val key: String?,
     val payload: ByteArray,
     val offset: Long,
-    val createdAt: Long
+    val createdAt: Instant
 )

--- a/src/main/kotlin/no/nav/helsemelding/outbound/model/OriginalMessage.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/model/OriginalMessage.kt
@@ -1,10 +1,11 @@
 package no.nav.helsemelding.outbound.model
 
 import kotlinx.serialization.Serializable
+import kotlin.time.Instant
 
 @Serializable
 data class OriginalMessage(
-    val createdAt: Long,
+    val createdAt: Instant,
     val key: String?,
     val payload: String?
 )

--- a/src/main/kotlin/no/nav/helsemelding/outbound/receiver/MessageReceiver.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/receiver/MessageReceiver.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.mapNotNull
 import no.nav.helsemelding.outbound.handler.MessageHandler
 import no.nav.helsemelding.outbound.model.DialogMessage
 import no.nav.helsemelding.outbound.model.MessageRecord
+import kotlin.time.Instant
 import kotlin.uuid.Uuid
 
 class MessageReceiver(
@@ -43,7 +44,7 @@ class MessageReceiver(
             key = key(),
             payload = value(),
             offset = offset.offset,
-            createdAt = timestamp()
+            createdAt = Instant.fromEpochMilliseconds(timestamp())
         )
 }
 

--- a/src/test/kotlin/no/nav/helsemelding/outbound/handler/MessageErrorHandlerSpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/outbound/handler/MessageErrorHandlerSpec.kt
@@ -33,7 +33,7 @@ class MessageErrorHandlerSpec : StringSpec(
                 key = "not-a-uuid",
                 payload = """{"foo":"bar"}""".encodeToByteArray(),
                 offset = 42L,
-                createdAt = Clock.System.now().epochSeconds
+                createdAt = Clock.System.now()
             )
 
             val validation = RecordKeyValidation.Invalid(
@@ -64,7 +64,7 @@ class MessageErrorHandlerSpec : StringSpec(
                 key = null,
                 payload = """{"foo":"bar"}""".encodeToByteArray(),
                 offset = 42L,
-                createdAt = Clock.System.now().epochSeconds
+                createdAt = Clock.System.now()
             )
 
             val validation = RecordKeyValidation.Invalid(


### PR DESCRIPTION
Milliseconds since Epoch isn't the most friendly format to work with so we convert to an `Instant` before writing out the error json. This also makes for easier reading when inspecting the topic via ie _Kafka Manager_.