### PR TITLE
Quick fix: Ta i bruk igjen `helsemelding_outgoing_messages_received` metrikken.

### DIFF
--- a/src/main/kotlin/no/nav/helsemelding/outbound/processor/MessageProcessor.kt
+++ b/src/main/kotlin/no/nav/helsemelding/outbound/processor/MessageProcessor.kt
@@ -27,6 +27,7 @@ class MessageProcessor(
 ) {
     fun processMessages(scope: CoroutineScope): Job =
         messageFlow()
+            .onEach { metrics.registerOutgoingMessageReceived() }
             .onEach { message ->
                 val durationNanos = measureNanoTime {
                     processMessage(message)


### PR DESCRIPTION
Denne linjen har sannsynligvis forsvant ved en av de tidligere endringene.